### PR TITLE
Fix mongo connections and deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ name: Deploy
 
 on:
   push:
-    branches: [development, staging, production]
+    branches: [development, staging, main]
     # Uncomment this for monorepos
     # paths: ['server/**']
 
@@ -37,10 +37,10 @@ jobs:
           aws-region: us-east-1
 
       - name: Install Dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
 
       - name: Deploy
-        run: npm run deploy -- --stage development
+        run: yarn run deploy  --stage development
         env:
           NODE_ENV: development
   Staging:
@@ -68,17 +68,17 @@ jobs:
           aws-region: us-east-1
 
       - name: Install Dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
 
       - name: Deploy
-        run: npm run deploy -- --stage staging
+        run: yarn run deploy --stage staging
         env:
           NODE_ENV: staging
 
   Production:
     runs-on: ubuntu-latest
 
-    if: github.ref == 'refs/heads/stage/production'
+    if: github.ref == 'refs/heads/main'
 
     strategy:
       matrix:
@@ -100,9 +100,9 @@ jobs:
           aws-region: us-east-1
 
       - name: Install Dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
 
       - name: Deploy
-        run: npm run deploy -- --stage production
+        run: yarn run deploy --stage production
         env:
           NODE_ENV: production

--- a/service/components/database.ts
+++ b/service/components/database.ts
@@ -1,38 +1,6 @@
-import mongoose, { Connection } from 'mongoose'
+import type { Connection } from 'mongoose'
 
-import config from '../configs/database'
-
-import schemas from './schemas'
-
-class MongoManager {
-  #loadedConnection: Promise<Connection>
-  setConnection(newConnection: Promise<Connection>) {
-    const loadConnection = async () => {
-      const connection = await newConnection
-
-      schemas.load(connection)
-
-      return connection
-    }
-
-    this.#loadedConnection = loadConnection()
-  }
-
-  async getConnection() {
-    if (this.#loadedConnection === undefined)
-      throw new Error('Must set a connection first')
-
-    return this.#loadedConnection
-  }
-  async disconnect(force = false) {
-    if (this.#loadedConnection) {
-      const conn = await this.#loadedConnection
-
-      await conn.close(force)
-      this.#loadedConnection = undefined
-    }
-  }
-}
+import { MongoManager } from '../util/MongoManager'
 
 export const manager = new MongoManager()
 
@@ -41,13 +9,6 @@ export const manager = new MongoManager()
  *
  */
 async function connect(): Promise<Connection> {
-  if (process.env.NODE_ENV !== 'test')
-    manager.setConnection(
-      mongoose
-        .createConnection(config.default.uri, config.default.options)
-        .asPromise(),
-    )
-
   const conn = await manager.getConnection()
 
   return conn

--- a/service/util/MongoManager.ts
+++ b/service/util/MongoManager.ts
@@ -1,0 +1,43 @@
+import mongoose, { Connection } from 'mongoose'
+
+import schemas from '../components/schemas'
+import config from '../configs/database'
+
+export class MongoManager {
+  #loadedConnection: Promise<Connection>
+  constructor() {
+    if (process.env.NODE_ENV !== 'test')
+      this.setConnection(
+        mongoose
+          .createConnection(config.default.uri, config.default.options)
+          .asPromise(),
+      )
+  }
+
+  setConnection(newConnection: Promise<Connection>): void {
+    const loadConnection = async () => {
+      const connection = await newConnection
+
+      schemas.load(connection)
+
+      return connection
+    }
+
+    this.#loadedConnection = loadConnection()
+  }
+
+  async getConnection(): Promise<Connection> {
+    if (this.#loadedConnection === undefined)
+      throw new Error('Must set a connection first')
+
+    return this.#loadedConnection
+  }
+  async disconnect(force = false): Promise<void> {
+    if (this.#loadedConnection) {
+      const conn = await this.#loadedConnection
+
+      await conn.close(force)
+      this.#loadedConnection = undefined
+    }
+  }
+}


### PR DESCRIPTION
- Use `yarn` for gh-actions deploys
- Fix mongo connections (just one connection shared across services)